### PR TITLE
bump python to 3.9 to support numpy 2

### DIFF
--- a/pykrak/adjoint.py
+++ b/pykrak/adjoint.py
@@ -205,7 +205,7 @@ def get_rfgh(krs, r):
     """
     M = krs.size
     #rfg_arr = np.zeros((M, M, M), dtype=nb.c8)
-    rfg_arr = np.zeros((M, M, M), dtype=np.complex_)
+    rfg_arr = np.zeros((M, M, M), dtype=np.complex128)
     krs_sq = krs**2
     for f in range(M):
         krf = krs[f]
@@ -254,7 +254,7 @@ def get_dpda(zfg, krs, r, phi_zr, phi_zs):
     receiver depths zr, and source depth zs
     Using equation 18a in Thode and Kim (2004)
     """
-    dpda = np.zeros(phi_zr.shape[0],dtype=np.complex_)
+    dpda = np.zeros(phi_zr.shape[0],dtype=np.complex128)
     M = krs.size
 
     rfg = get_rfg(krs, r)
@@ -278,7 +278,7 @@ def get_mode_dpda(zfg, krs, r, phi_zs):
     d A / d a = ... \sum
     """
     M = krs.size
-    mode_dpda = np.zeros(M, dtype=np.complex_)
+    mode_dpda = np.zeros(M, dtype=np.complex128)
     M = krs.size
     rfg = get_rfg(krs, r)
     prod = zfg * rfg
@@ -303,7 +303,7 @@ def get_dpdaidaj(zfg_ai, zfg_aj, zfg_aiaj, krs, r, phi_zr, phi_zs):
     rfg = get_rfg(krs, r)
 
     Nr = phi_zr.shape[0]
-    dpdaidaj = np.zeros((Nr), dtype=np.complex_)
+    dpdaidaj = np.zeros((Nr), dtype=np.complex128)
     M = krs.size
     for f in range(M):
         for g in range(M):
@@ -442,9 +442,9 @@ def get_kernel(h_arr, ind_arr, z_arr, c_arr, rho_arr, krs, phi_z, phi, omega, zr
 
     integrator = integrator[::stride]
     M = krs.size
-    kernel = np.zeros((zr.size, rgrid.size, integrator.size), dtype=np.complex_)
+    kernel = np.zeros((zr.size, rgrid.size, integrator.size), dtype=np.complex128)
     for j in range(zr.size):
-        kernel_j = np.zeros((rgrid.size, integrator.size), dtype=np.complex_)
+        kernel_j = np.zeros((rgrid.size, integrator.size), dtype=np.complex128)
         for f in range(M):
             uf = phi[::stride,f]
             krf = krs[f]

--- a/pykrak/pressure_calc.py
+++ b/pykrak/pressure_calc.py
@@ -232,10 +232,10 @@ def get_vec_pressure(phi_zr, phi_zs, krs, rgrid, tilt_angles=None, zr=None):
     """
     num_track_pts = rgrid.size
     num_depths = phi_zr.shape[0]
-    full_p = np.zeros((num_depths, num_track_pts), dtype=np.complex_)
+    full_p = np.zeros((num_depths, num_track_pts), dtype=np.complex128)
     for i in range(num_track_pts):
         modal_matrix = phi_zr * phi_zs[:,i]
-        modal_matrix = modal_matrix.astype(np.complex_)
+        modal_matrix = modal_matrix.astype(np.complex128)
         r = rgrid[i]
         if tilt_angles is not None:
             tilt_angle = tilt_angles[i]
@@ -301,7 +301,7 @@ def get_grid_pressure(zr, phi_z, phi, krs, zgrid, rgrid, tilt_angle=None):
         r_corr = get_range_correction(zr, tilt_angle)
     else:
         r_corr = np.zeros(zr.size)
-    pfield = np.zeros((Nzr, zgrid.size, rgrid.size), dtype=np.complex_)
+    pfield = np.zeros((Nzr, zgrid.size, rgrid.size), dtype=np.complex128)
 
     # interpolate the modes to the grid depths (they are ``receivers'' in reciprocity)
     phi_zr = np.zeros((zgrid.size, krs.size))
@@ -352,10 +352,10 @@ def get_doppler_vec_pressure(phi_zr, phi_zs, krs, r_ret_grid, t_ret_grid, ums, c
 
     num_track_pts = contemp_tgrid.size
     num_zrs = phi_zr.shape[0]
-    full_p = np.zeros((num_zrs, num_track_pts), dtype=np.complex_)
+    full_p = np.zeros((num_zrs, num_track_pts), dtype=np.complex128)
     for j in range(zr.size):
         modal_matrix = phi_zr[j,:].reshape(krs.size,1) * phi_zs_dopp
-        modal_matrix = modal_matrix.astype(np.complex_)
+        modal_matrix = modal_matrix.astype(np.complex128)
         if tilt_angles is not None:
             deltaR = Z[j]*np.tan(tilt_angles * np.pi / 180.)
             zr_rgrids = rgrids + deltaR
@@ -382,7 +382,7 @@ def get_doppler_vec_pressure_deriv(phi_zr, phi_zs, dphir_dk, dphis_dk, kr, r_ret
 
     num_track_pts = contemp_tgrid.size
     num_zrs = phi_zr.shape[0]
-    full_deriv = np.zeros((num_zrs, num_track_pts), dtype=np.complex_)
+    full_deriv = np.zeros((num_zrs, num_track_pts), dtype=np.complex128)
 
     for j in range(zr.size):
         A = phi_zr[j,0] * phi_zs_dopp
@@ -419,11 +419,11 @@ def get_simple_doppler_vec_pressure(phi_zr, phi_zs, krs, rgrid, tgrid, ums, tilt
     """
     num_track_pts = rgrid.size
     num_depths = phi_zr.shape[0]
-    full_p = np.zeros((num_depths, num_track_pts), dtype=np.complex_)
+    full_p = np.zeros((num_depths, num_track_pts), dtype=np.complex128)
     dt = tgrid[1] - tgrid[0]     
     for i in range(num_track_pts):
         modal_matrix = phi_zr * phi_zs[:,i]
-        modal_matrix = modal_matrix.astype(np.complex_)
+        modal_matrix = modal_matrix.astype(np.complex128)
         r = rgrid[i]
         if i == 0:
             v = (rgrid[1] - rgrid[0]) / dt

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
     ],
     packages=["pykrak"],
-    python_requires=">=3.7, <4",
+    python_requires=">=3.9, <4",
     install_requires=["numba", "numpy", "scipy", "matplotlib"],
 )
     


### PR DESCRIPTION
Hi, I hope you are doing well.

I've tried to test your package recently with the provided `example/pekeris.py`, but as there is no dependency versioning scheme, there was an issue running it. 

Mainly what happens is that the default numpy version installed is 2.0.2.

So I made it work by simply replacing `np.complex_` dtype with `np.complex128` as well as bumping the minimum python version to 3.9.

There might be other compatibility issues with the passage to numpy 2.0.2 that I'm not aware of yet, but I found that the other examples were relying on an `env` package, which I suppose is the one in your GitHub but I didn't have time to try them yet!

A better solution might just be to add the appropriate package version in the `setup.py` or limit the python version to 3.8.

If you want a summary of package versions that seem to work:
```toml
requires-python = ">=3.9"
dependencies = [
    "matplotlib>=3.9.4",
    "numba>=0.60.0",
    "numpy>=2.0.2",
    "scipy>=1.13.1",
]
```