### PR TITLE
Add test dependency to pyat

### DIFF
--- a/pykrak/test_helpers.py
+++ b/pykrak/test_helpers.py
@@ -8,14 +8,16 @@ Author: Hunter Akins
 Institution: Scripps Institution of Oceanography, UC San Diego
 """
 
+import os
+
+import matplotlib
 import numpy as np
 from matplotlib import pyplot as plt
 from matplotlib import rc
-import matplotlib
-from pyat.pyat.readwrite import read_env, read_modes
-from pyat.pyat import env as pyat_env
+from pyat import env as pyat_env
+from pyat.readwrite import read_env, read_modes
+
 from pykrak.pykrak_env import Env
-import os
 
 
 def read_krs_from_prt_file(prt_file, verbose=True):

--- a/pykrak/tests/kraken_comparison.py
+++ b/pykrak/tests/kraken_comparison.py
@@ -14,7 +14,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from pykrak import test_helpers as th
-from pyat.pyat import readwrite as rw
+from pyat import readwrite as rw
 from pykrak import krak_routines as kr
 from pykrak import field as field
 import os

--- a/pykrak/tests/multi_freq_adia_test.py
+++ b/pykrak/tests/multi_freq_adia_test.py
@@ -11,7 +11,7 @@ Institution: Scripps Institution of Oceanography, UC San Diego
 
 import numpy as np
 from matplotlib import pyplot as plt
-from pyat.pyat.readwrite import (
+from pyat.readwrite import (
     read_env,
     write_env,
     write_fieldflp,
@@ -24,7 +24,7 @@ from pykrak.test_helpers import get_krak_inputs
 
 # from pykrak.adia_model import MultiFrequencyAdiabaticModel
 from pykrak.mf_model import MultiFrequencyModel
-from pyat.pyat import env as pyat_env
+from pyat import env as pyat_env
 from mpi4py import MPI
 import os
 import time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,5 +16,9 @@ dev = [
   "ruff>=0.12.5",
 ]
 test = [
+  "pyat",
   "scipy>=1.15.3",
 ]
+
+[tool.uv.sources]
+pyat = { git = "https://github.com/hunterakins/pyat" }


### PR DESCRIPTION
Reading the issues #9. I've added pyat as a test dependency from the git repo (i.e)

``` sh
uv add --group=test git+https://github.com/hunterakins/pyat
```

And renamed the `import pyat.pyat` to just `import pyat` to make it work. 

That way I think this is not a mandatory dependency but if user want to try it they can by installing the test group and we don't need to manage it separately or add stuff from pyat randomly to make it work.

Also we could use it in the future for further test or comparison if needed!

I think we might want to move every test file into the same folder as well.

Let me know what you think of it!