### PR TITLE
Update krak_routines.py

### DIFF
--- a/pykrak/krak_routines.py
+++ b/pykrak/krak_routines.py
@@ -499,7 +499,7 @@ def acoustic_layers(
         p2 = (b1[ii] - h2k2) * g - 2.0 * hMedium * f * rhoMedium
 
         # Shoot (towards surface) through a single medium
-        for ii in range(ind_arr[Medium] + NMedium - 1, ind_arr[Medium], -1):
+        for ii in range(ind_arr[Medium] + NMedium - 2, ind_arr[Medium]-1, -1):
             p0 = p1
             p1 = p2
             p2 = (h2k2 - b1[ii]) * p1 - p0


### PR DESCRIPTION
Caught the error that was causing the linear profiles to fail. I was indexing the bottom point of each layer in the shooting instead of the point directly above it. Then the last point indexed is the point directly below the upper interface. This did not cause an issue in constant layers because there was no difference between the bottom interface point (from within the layer) and the  top point. However this causes a difference when there is a linear gradient.