### PR TITLE
Add test comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,9 @@ Install development and testing dependencies using
 uv sync --all-groups
 ```
 
+## Tests
+Some basic tests are implemented to compare the results of the modal parameters $k_r$ and $\Psi$ to the original `KRAKEN` program.
 
+``` sh
+uv run pytest
+```

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    """Adds the --plots command line flag."""
+    parser.addoption(
+        "--plots",
+        action="store_true",
+        default=False,
+        help="Display plots during test execution.",
+    )
+
+
+@pytest.fixture
+def plots_enabled(request):
+    """Fixture that returns True if --plots is passed."""
+    return request.config.getoption("--plots")

--- a/pykrak/tests/test_comparison.py
+++ b/pykrak/tests/test_comparison.py
@@ -1,0 +1,214 @@
+"""
+Description:
+    Compare pykrak and to kraken wavenumber and modal depth function estimates
+"""
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pytest
+from matplotlib import pyplot as plt
+from matplotlib.lines import Line2D
+from pyat import readwrite as rw
+from pykrak import field as field
+from pykrak import krak_routines as kr
+from pykrak import test_helpers as th
+
+env_test_files = list(
+    map(
+        lambda x: Path("pykrak", "tests", "at_files", x),
+        [
+            "ice",
+            "atten",
+            "elsed",
+            "flused",
+            "double",
+            "ice_env",
+            "solve2test",
+            "pekeris_layer_attn",
+            "pekeris",
+            "pekeris_attn",
+            "pekeris_rough_bdry",
+        ],
+    )
+)
+
+
+@pytest.mark.parametrize("env", env_test_files, ids=lambda path: path.stem)
+def test_kr_comp(env: Path):
+    TitleEnv, freq, ssp, bdry, pos, beam, cint, RMax = rw.read_env(
+        str(env.with_suffix(".env")), "kraken"
+    )
+    c_low, c_high = cint.Low, cint.High
+
+    modes = rw.read_modes(**{"fname": str(env.with_suffix(".mod")), "freq": freq})
+    z = modes.z
+    krak_prt_k, mode_nums, vps, vgs = th.read_krs_from_prt_file(
+        str(env.with_suffix(".prt")), verbose=False
+    )
+    krak_prt_k = np.array(krak_prt_k)
+
+    RMax = RMax * 1e3  # Convert to meters
+
+    (
+        pykrak_env,
+        N_list,
+        z_list,
+        cp_list,
+        cs_list,
+        rho_list,
+        attnp_list,
+        attns_list,
+        cp_hs,
+        cs_hs,
+        rho_hs,
+        attnp_hs,
+        attns_hs,
+        pos,
+        beam,
+        cint,
+        RMax,
+    ) = th.init_pykrak_env(ssp, bdry, pos, beam, cint, RMax)
+    pk_krs, phi_z, phi, ugs = pykrak_env.get_modes(
+        freq, N_list, rmax=RMax, c_low=c_low, c_high=c_high
+    )
+
+    max_mode_idx = None
+    if modes.M != pk_krs.size:
+        warnings.warn(
+            f"Warning: Number of modes in kraken and pykrak do not match! {modes.M} != {pk_krs.size} for envs {env}"
+        )
+        max_mode_idx = min(modes.M, pk_krs.size)
+
+    failures = {}
+    for i_m, mode_num in enumerate(mode_nums):
+        if max_mode_idx is not None:
+            if (i_m < max_mode_idx) or (mode_num < max_mode_idx):
+                break
+        try:
+            assert np.isclose(
+                krak_prt_k[i_m],
+                pk_krs[mode_num - 1],
+                atol=2 * np.pi * freq / c_high * 1e-18,
+            ), f"""Larger error in real part of horizontal wavenumber for env {env.stem} at mode {mode_num}.
+            Found kraken : {krak_prt_k[i_m]} | pykrak {pk_krs[mode_num - 1]}
+            """
+        except AssertionError as e:
+            failures[mode_num] = (krak_prt_k[i_m], pk_krs[mode_num - 1])
+
+    if failures:
+        failures_table_header = f"\n| mode  | {'kraken':12} | {'pykrak':12} |"
+        failures_table_content = "\n".join(
+            f"| {k:5} | {v[0]:12} | {v[1]:12} |" for k, v in failures.items()
+        )
+        raise AssertionError(
+            f"""Larger error in horizontal wavenumber for env {env.stem} at modes {list(failures.keys())}.
+            Found: {failures_table_header}\n{failures_table_content}
+            """
+        )
+
+
+@pytest.mark.parametrize("env", env_test_files, ids=lambda path: path.stem)
+def test_phi_comp(env: Path, plots_enabled):
+    TitleEnv, freq, ssp, bdry, pos, beam, cint, RMax = rw.read_env(
+        str(env.with_suffix(".env")), "kraken"
+    )
+
+    c_low, c_high = cint.Low, cint.High
+
+    modes = rw.read_modes(**{"fname": str(env.with_suffix(".mod")), "freq": freq})
+    krak_phi = modes.phi
+
+    krak_prt_k, mode_nums, vps, vgs = th.read_krs_from_prt_file(
+        str(env.with_suffix(".prt")), verbose=False
+    )
+    z = modes.z
+
+    RMax = RMax * 1e3
+
+    (
+        pykrak_env,
+        N_list,
+        z_list,
+        cp_list,
+        cs_list,
+        rho_list,
+        attnp_list,
+        attns_list,
+        cp_hs,
+        cs_hs,
+        rho_hs,
+        attnp_hs,
+        attns_hs,
+        pos,
+        beam,
+        cint,
+        RMax,
+    ) = th.init_pykrak_env(ssp, bdry, pos, beam, cint, RMax)
+
+    pk_krs, phi_z, pk_phi, ugs = pykrak_env.get_modes(
+        freq, N_list, rmax=RMax, c_low=c_low, c_high=c_high
+    )
+    phi_new = np.zeros((z.size, pk_phi.shape[1]))
+    for i in range(pk_phi.shape[1]):
+        phi_new[:, i] = np.interp(z, phi_z, pk_phi[:, i])
+
+    pk_phi = phi_new
+    phi_z = z
+
+    max_mode_idx = None
+    if modes.M != pk_krs.size:
+        warnings.warn(
+            f"Warning: Number of modes in kraken and pykrak do not match! {modes.M} != {pk_krs.size} for envs {env}"
+        )
+        max_mode_idx = min(modes.M, pk_krs.size)
+
+    failures = {}
+    for i_m, (krak_phi_m, pk_phi_m) in enumerate(zip(krak_phi.real.T, pk_phi.T)):
+        if max_mode_idx is not None:
+            if i_m < max_mode_idx:
+                break
+        try:
+            assert np.allclose(
+                pk_phi_m, krak_phi_m, atol=1e-6
+            ), f"""Larger error on modal depth function for env {env.stem} at mode {i_m + 1}.
+            """
+            # Found kraken : {krak_prt_k[i_m]} | pykrak {pk_krs.real[mode_num - 1]}
+        except AssertionError as e:
+            # pass
+            failures[i_m + 1] = (krak_phi_m, pk_phi_m)
+
+    if failures:
+        if plots_enabled:
+            custom_lines = [
+                Line2D([0], [0], color="k", label="pykrak"),
+                Line2D([0], [0], color="k", marker="x", lw=0, label="kraken"),
+            ]
+            plt.figure()
+            plt.title(f"Env {env.stem}")
+            u = 0
+            for m, (krak_phi_m, pk_phi_m) in failures.items():
+                u += 1
+                line = plt.plot(pk_phi_m, z, label=f"mode {m + 1}")
+                plt.plot(krak_phi_m, z, "x", color=line[0].get_color())
+                if u % 10 == 0:  # split into different figure for 10 failures
+                    if len(failures) > u:
+                        plt.legend(loc=2, handles=custom_lines)
+                        plt.gca().invert_yaxis()
+                        plt.figure()
+                        plt.title(f"Env {env.stem}")
+
+            print("1")
+            plt.legend(handles=custom_lines)
+            plt.gca().invert_yaxis()
+            plt.show()
+        raise AssertionError(
+            f"""Larger error on modal depth function for env {env.stem} at modes {list(failures.keys())}.
+            """
+        )
+
+
+if __name__ == ("__main__"):
+    # test_kr_comp(env_test_files[4])
+    test_phi_comp(env_test_files[5], True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,15 @@ dev = [
 ]
 test = [
   "pyat",
+  "pytest>=9.0.1",
   "scipy>=1.15.3",
 ]
+
+[tool.pytest]
+addopts = [
+  "--import-mode=importlib",
+]
+python_files = ["test_*.py"]
 
 [tool.uv.sources]
 pyat = { git = "https://github.com/hunterakins/pyat" }


### PR DESCRIPTION
Hi, I've delayed the push of this branch for far too long!

Seeing that you've fixed a bug recently motivated me to finally make this PR.

# Automatic testing using pytest
I've added a file `pykrak/tests/test_comparison.py` comparing outputs for the horizontal wavenumber and the modal depth function using [numpy.isclose](https://numpy.org/doc/stable/reference/generated/numpy.isclose.html). 
I've added the appropriate configuration using [pytest](https://docs.pytest.org/en/stable/)
## What it does
I'm comparing each output's value across modes (and depth for the modal depth function).

### Notes
While not perfect, it should enable us to quickly see regression when they are introduced but also compare new inputs/outputs for different environments.

This is currently not super optimized, as the model is entirely rerun for the modal depth function and for the wavenumber (so 2 runs per environment are necessary).

## How to use it
```sh
pytest # or `uv run pytest` if you're venv is not activated
```
### Compare one env or one output
[Run test using keyword expression](https://docs.pytest.org/en/stable/how-to/usage.html), for example, using the stem of the environment file defined in `pykrak/tests/at_files/...`
```sh
pytest -k 'kr_ and pekeris'
```

### Modal depth function plots
I've also added a fixture to quickly plot and identify where the issues could come from in the modal depth functions.
```sh
pytest --plots
```

## Current test status with this branch
Currently everything seems fine except for two little things.
1. Some environments (i.e., `ice_env`, `solve2test`) don't seem to include the top and bottom layers (that might be expected; I didn't dive into it too deep and just moved on while checking I wasn't introducing new regression).
2. `flused` is missing one mode (45 found instead of 46 for Kraken). But we might just be really close from a branch cut, and a compilation difference might lead to this discrepancy.

### Below is the current summary that I get currently
```sh
================================================= warnings summary =================================================
pykrak/tests/test_comparison.py::test_kr_comp[flused]
  /home/arthurvaron/Documents/pykrak/pykrak/tests/test_comparison.py:79: UserWarning: Warning: Number of modes in kraken and pykrak do not match! 46 != 45 for envs pykrak/tests/at_files/flused
    warnings.warn(

pykrak/tests/test_comparison.py::test_phi_comp[flused]
  /home/arthurvaron/Documents/pykrak/pykrak/tests/test_comparison.py:162: UserWarning: Warning: Number of modes in kraken and pykrak do not match! 46 != 45 for envs pykrak/tests/at_files/flused
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================= short test summary info ==============================================
FAILED pykrak/tests/test_comparison.py::test_phi_comp[ice_env] - AssertionError: Larger error on modal depth function for env ice_env at modes [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].
FAILED pykrak/tests/test_comparison.py::test_phi_comp[solve2test] - AssertionError: Larger error on modal depth function for env solve2test at modes [1, 2, 3].
==================================== 2 failed, 20 passed, 17 warnings in 51.83s ====================================
```

### Here are the plots for the failed tests
<img width="2048" height="1036" alt="solve2test" src="https://github.com/user-attachments/assets/8e60a46a-7ec1-43a9-8d24-426d810026f8" />
<img width="2048" height="1036" alt="ice_env" src="https://github.com/user-attachments/assets/25bba62f-27bd-4847-833c-6d06a6cfefe8" />
